### PR TITLE
(fbz-9134) added custom maint page option

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -193,7 +193,7 @@ RUN set -x && \
 COPY . /
 
 # Fix some permissions since we'll be running as a non-root user
-RUN chown -R router:router /opt/router /var/log
+RUN chown -R router:router /opt/router /var/log /www
 
 USER router
 

--- a/rootfs/opt/router/sbin/boot
+++ b/rootfs/opt/router/sbin/boot
@@ -5,4 +5,13 @@ set -eof pipefail
 mkfifo -m 600 /tmp/logpipe
 cat < /tmp/logpipe 1>&2 &
 
+# set custom maintenance page on router startup. 
+# this can be specified via optional MAINTENANCE_PAGE_URL environment variable.
+
+if [[ "$MAINTENANCE_PAGE_URL" == *".html" ]]; then 
+	if ( curl -o/dev/null -sfI "$MAINTENANCE_PAGE_URL" ); then 
+		curl -o /www/maintenance.html $MAINTENANCE_PAGE_URL; 
+	fi; 
+fi;
+
 exec /opt/router/sbin/router


### PR DESCRIPTION
Fixed /www permissions so deploy user that runs the container can write to maintanace.html 
Added a logic into the boot script to pull custom maintenance page defined in the environment variable MAINTENANCE_PAGE_URL